### PR TITLE
fix: Deprecation with PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
+        ini-values: error_reporting=E_ALL, display_errors=On
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug

--- a/src/MySQLReplication/BinLog/BinLogCurrent.php
+++ b/src/MySQLReplication/BinLog/BinLogCurrent.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace MySQLReplication\BinLog;
 
 use JsonSerializable;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class BinLogCurrent implements JsonSerializable
 {
+    use JsonSerializableTrait;
+
     /**
      * @var int
      */
@@ -62,10 +65,5 @@ class BinLogCurrent implements JsonSerializable
     public function setMariaDbGtid(string $mariaDbGtid): void
     {
         $this->mariaDbGtid = $mariaDbGtid;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Config/Config.php
+++ b/src/MySQLReplication/Config/Config.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace MySQLReplication\Config;
 
 use JsonSerializable;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class Config implements JsonSerializable
 {
+    use JsonSerializableTrait;
+
     private $user;
     private $host;
     private $port;
@@ -237,10 +240,5 @@ class Config implements JsonSerializable
     public function getRetry(): int
     {
         return $this->retry;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/FormatDescriptionEventDTO.php
+++ b/src/MySQLReplication/Event/DTO/FormatDescriptionEventDTO.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class FormatDescriptionEventDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $type = ConstEventsNames::FORMAT_DESCRIPTION;
 
     public function getType(): string
@@ -21,10 +24,5 @@ class FormatDescriptionEventDTO extends EventDTO
             'Date: ' . $this->eventInfo->getDateTime() . PHP_EOL .
             'Log position: ' . $this->eventInfo->getPos() . PHP_EOL .
             'Event size: ' . $this->eventInfo->getSize() . PHP_EOL;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/GTIDLogDTO.php
+++ b/src/MySQLReplication/Event/DTO/GTIDLogDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class GTIDLogDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $commit;
     private $gtid;
     private $type = ConstEventsNames::GTID;
@@ -53,10 +56,5 @@ class GTIDLogDTO extends EventDTO
             'Event size: ' . $this->eventInfo->getSize() . PHP_EOL .
             'Commit: ' . var_export($this->commit, true) . PHP_EOL .
             'GTID NEXT: ' . $this->gtid . PHP_EOL;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/HeartbeatDTO.php
+++ b/src/MySQLReplication/Event/DTO/HeartbeatDTO.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class HeartbeatDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     protected $type = ConstEventsNames::HEARTBEAT;
 
     public function __toString(): string
@@ -21,10 +24,5 @@ class HeartbeatDTO extends EventDTO
     public function getType(): string
     {
         return $this->type;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/MariaDbGtidLogDTO.php
+++ b/src/MySQLReplication/Event/DTO/MariaDbGtidLogDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class MariaDbGtidLogDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $type = ConstEventsNames::MARIADB_GTID;
     private $flag;
     private $domainId;
@@ -42,12 +45,6 @@ class MariaDbGtidLogDTO extends EventDTO
     public function getType(): string
     {
         return $this->type;
-    }
-
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 
     public function getFlag(): int

--- a/src/MySQLReplication/Event/DTO/QueryDTO.php
+++ b/src/MySQLReplication/Event/DTO/QueryDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class QueryDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $executionTime;
     private $query;
     private $database;
@@ -56,10 +59,5 @@ class QueryDTO extends EventDTO
             'Database: ' . $this->database . PHP_EOL .
             'Execution time: ' . $this->executionTime . PHP_EOL .
             'Query: ' . $this->query . PHP_EOL;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/RotateDTO.php
+++ b/src/MySQLReplication/Event/DTO/RotateDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class RotateDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $position;
     private $nextBinlog;
     private $type = ConstEventsNames::ROTATE;
@@ -47,10 +50,5 @@ class RotateDTO extends EventDTO
             'Event size: ' . $this->eventInfo->getSize() . PHP_EOL .
             'Binlog position: ' . $this->position . PHP_EOL .
             'Binlog filename: ' . $this->nextBinlog . PHP_EOL;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/RowsDTO.php
+++ b/src/MySQLReplication/Event/DTO/RowsDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Event\EventInfo;
 use MySQLReplication\Event\RowEvent\TableMap;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 abstract class RowsDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $values;
     private $changedRows;
     private $tableMap;
@@ -51,10 +54,5 @@ abstract class RowsDTO extends EventDTO
             'Affected columns: ' . $this->tableMap->getColumnsAmount() . PHP_EOL .
             'Changed rows: ' . $this->changedRows . PHP_EOL .
             'Values: ' . print_r($this->values, true) . PHP_EOL;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/DTO/TableMapDTO.php
+++ b/src/MySQLReplication/Event/DTO/TableMapDTO.php
@@ -6,9 +6,12 @@ namespace MySQLReplication\Event\DTO;
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
 use MySQLReplication\Event\RowEvent\TableMap;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class TableMapDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $type = ConstEventsNames::TABLE_MAP;
     private $tableMap;
 
@@ -37,11 +40,6 @@ class TableMapDTO extends EventDTO
     public function getType(): string
     {
         return $this->type;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 
     public function getTableMap(): TableMap

--- a/src/MySQLReplication/Event/DTO/XidDTO.php
+++ b/src/MySQLReplication/Event/DTO/XidDTO.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event\DTO;
 
 use MySQLReplication\Definitions\ConstEventsNames;
 use MySQLReplication\Event\EventInfo;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class XidDTO extends EventDTO
 {
+    use JsonSerializableTrait;
+
     private $type = ConstEventsNames::XID;
     private $xid;
 
@@ -38,10 +41,5 @@ class XidDTO extends EventDTO
     public function getType(): string
     {
         return $this->type;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/EventInfo.php
+++ b/src/MySQLReplication/Event/EventInfo.php
@@ -5,9 +5,12 @@ namespace MySQLReplication\Event;
 
 use JsonSerializable;
 use MySQLReplication\BinLog\BinLogCurrent;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class EventInfo implements JsonSerializable
 {
+    use JsonSerializableTrait;
+
     private $timestamp;
     private $type;
     private $id;
@@ -95,10 +98,5 @@ class EventInfo implements JsonSerializable
     public function getFlag(): int
     {
         return $this->flag;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Event/RowEvent/TableMap.php
+++ b/src/MySQLReplication/Event/RowEvent/TableMap.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace MySQLReplication\Event\RowEvent;
 
 use JsonSerializable;
+use MySQLReplication\Util\JsonSerializableTrait;
 
 class TableMap implements JsonSerializable
 {
+    use JsonSerializableTrait;
+
     private $database;
     private $table;
     private $tableId;
@@ -53,10 +56,5 @@ class TableMap implements JsonSerializable
     public function getColumnDTOCollection(): ColumnDTOCollection
     {
         return $this->columnDTOCollection;
-    }
-
-    public function jsonSerialize()
-    {
-        return get_object_vars($this);
     }
 }

--- a/src/MySQLReplication/Util/JsonSerializableTrait.php
+++ b/src/MySQLReplication/Util/JsonSerializableTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MySQLReplication\Util;
+
+use function get_object_vars;
+
+/**
+ * Provide implementation of {@see JsonSerializable::jsonSerialize()} which dumps all properties (public or private).
+ */
+trait JsonSerializableTrait
+{
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}


### PR DESCRIPTION
Main repository seams to be dead, and this repository is the most active one, so...

Fixes issue https://github.com/krowinski/php-mysql-replication/issues/89
by adding return typehint (which is required since PHP 8.1 because native API are now typehinted), and also refactoring `jsonSerialize()` into a trait.

I also added error reporting on github action to show actual deprecation and notice.