### PR TITLE
Improve MySQLReplication BinaryDataReader

### DIFF
--- a/src/MySQLReplication/BinaryDataReader/BinaryDataReader.php
+++ b/src/MySQLReplication/BinaryDataReader/BinaryDataReader.php
@@ -172,6 +172,9 @@ class BinaryDataReader
         if ($size === self::UNSIGNED_INT56_LENGTH) {
             return $this->readUInt56();
         }
+        if ($size === self::UNSIGNED_INT64_LENGTH) {
+            return intval($this->readUInt64());
+        }
 
         throw new BinaryDataReaderException('$size ' . $size . ' not handled');
     }


### PR DESCRIPTION
fix #10 

- Add support for reading 64-bit unsigned integers
- Change the return type of `readUInt56()` from `string` to `int`