### PR TITLE
Fix leave the response for the event consumer

### DIFF
--- a/src/MySQLReplication/BinLog/BinLogSocketConnect.php
+++ b/src/MySQLReplication/BinLog/BinLogSocketConnect.php
@@ -300,7 +300,6 @@ class BinLogSocketConnect
         $data .= $binFileName;
 
         $this->socket->writeToSocket($data);
-        $this->getResponse();
 
         $binLogCurrent->setBinLogPosition($binFilePos);
         $binLogCurrent->setBinFileName($binFileName);

--- a/tests/Integration/BaseTest.php
+++ b/tests/Integration/BaseTest.php
@@ -12,6 +12,7 @@ use MySQLReplication\Definitions\ConstEventType;
 use MySQLReplication\Event\DTO\EventDTO;
 use MySQLReplication\Event\DTO\FormatDescriptionEventDTO;
 use MySQLReplication\Event\DTO\QueryDTO;
+use MySQLReplication\Event\DTO\RotateDTO;
 use MySQLReplication\Event\DTO\TableMapDTO;
 use MySQLReplication\MySQLReplicationFactory;
 use PHPUnit\Framework\TestCase;
@@ -61,6 +62,7 @@ abstract class BaseTest extends TestCase
 
         $this->connect();
 
+        self::assertInstanceOf(RotateDTO::class, $this->getEvent());
         self::assertInstanceOf(FormatDescriptionEventDTO::class, $this->getEvent());
         self::assertInstanceOf(QueryDTO::class, $this->getEvent());
         self::assertInstanceOf(QueryDTO::class, $this->getEvent());

--- a/tests/Integration/BasicTest.php
+++ b/tests/Integration/BasicTest.php
@@ -401,6 +401,7 @@ class BasicTest extends BaseTest
         $this->connection->executeStatement('USE ' . $this->database);
         $this->connection->executeStatement('SET SESSION sql_mode = \'\';');
 
+        self::assertInstanceOf(RotateDTO::class, $this->getEvent());
         self::assertInstanceOf(FormatDescriptionEventDTO::class, $this->getEvent());
         self::assertInstanceOf(QueryDTO::class, $this->getEvent());
         self::assertInstanceOf(QueryDTO::class, $this->getEvent());


### PR DESCRIPTION
Mariadb send Fake ROTATE_EVENT  immediately after COM_BINLOG_DUMP https://mariadb.com/kb/en/5-slave-registration/#events-transmission-after-com_binlog_dump.
If we read it here the Event Consumer doesn't process it.